### PR TITLE
Switching from nose to py.test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ install:
 
   # Replace dep1 dep2 ... with your dependencies
   - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy h5py pytest pip flake8 coverage
-  - pip install pytest-cov
-  - pip install coveralls
   - source activate testenv
+  - pip install coveralls
+  - pip install pytest-cov
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy h5py nose pip flake8 coverage
+  - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy h5py pytest pip flake8 coverage
+  - pip install pytest-cov
   - pip install coveralls
   - source activate testenv
   - python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	flake8 phy --exclude=phy/ext/six.py --ignore=E226,E265,F401
 
 test: lint
-	nosetests --exe --with-coverage --cover-package=phy --cover-erase
+	py.test --cov phy
 
 release: clean
 	python setup.py sdist upload

--- a/phy/io/tests/test_h5.py
+++ b/phy/io/tests/test_h5.py
@@ -10,7 +10,7 @@ import os
 
 import numpy as np
 import h5py
-from nose.tools import assert_raises
+from pytest import raises
 
 from ...utils.tempdir import TemporaryDirectory
 from ...utils.testing import captured_output
@@ -50,8 +50,10 @@ def _create_test_file():
 
 def test_split_hdf5_path():
     # The path should always start with a leading '/'.
-    assert_raises(ValueError, _split_hdf5_path, '')
-    assert_raises(ValueError, _split_hdf5_path, 'path')
+    with raises(ValueError):
+        _split_hdf5_path('')
+    with raises(ValueError):
+        _split_hdf5_path('path')
 
     h, t = _split_hdf5_path('/')
     assert (h == '/') and (t == '')
@@ -69,9 +71,12 @@ def test_split_hdf5_path():
     assert (h == '/path/to') and (t == '')
 
     # Check that invalid paths raise errors.
-    assert_raises(ValueError, _split_hdf5_path, 'path/')
-    assert_raises(ValueError, _split_hdf5_path, '/path//')
-    assert_raises(ValueError, _split_hdf5_path, '/path//to')
+    with raises(ValueError):
+        _split_hdf5_path('path/')
+    with raises(ValueError):
+        _split_hdf5_path('/path//')
+    with raises(ValueError):
+        _split_hdf5_path('/path//to')
 
 
 def test_h5_read():
@@ -88,7 +93,8 @@ def test_h5_read():
         assert f.is_open()
         f.close()
         assert not f.is_open()
-        assert_raises(IOError, f.describe)
+        with raises(IOError):
+            f.describe()
 
         # Open the test HDF5 file.
         with open_h5(filename) as f:
@@ -111,10 +117,14 @@ def test_h5_read():
             assert value == 123
 
             # Check that errors are raised when the paths are invalid.
-            assert_raises(Exception, f.read, '//path')
-            assert_raises(Exception, f.read, '/path//')
-            assert_raises(KeyError, f.read, '/nonexistinggroup')
-            assert_raises(KeyError, f.read, '/nonexistinggroup/ds34')
+            with raises(Exception):
+                f.read('//path')
+            with raises(Exception):
+                f.read('/path//')
+            with raises(KeyError):
+                f.read('/nonexistinggroup')
+            with raises(KeyError):
+                f.read('/nonexistinggroup/ds34')
 
         assert not f.is_open()
 
@@ -136,14 +146,16 @@ def test_h5_write():
         # Open the test HDF5 file in read-only mode (the default) and
         # try to write in it. This should raise an exception.
         with open_h5(filename) as f:
-            assert_raises(Exception, lambda: f.write('/ds1', temp_array))
+            with raises(Exception):
+                f.write('/ds1', temp_array)
 
         # Open the test HDF5 file in read/write mode and
         # try to write in an existing dataset.
         with open_h5(filename, 'a') as f:
             # This raises an exception because the file already exists,
             # and by default this is forbidden.
-            assert_raises(ValueError, lambda: f.write('/ds1', temp_array))
+            with raises(ValueError):
+                f.write('/ds1', temp_array)
 
             # This works, though, because we force overwriting the dataset.
             f.write('/ds1', temp_array, overwrite=True)
@@ -164,8 +176,8 @@ def test_h5_write():
 
             # Write a new attribute in a non existing group: should raise
             # an error.
-            assert_raises(KeyError, f.write_attr,
-                          '/nonexistinggroup', 'mynewattr', 2)
+            with raises(KeyError):
+                f.write_attr('/nonexistinggroup', 'mynewattr', 2)
 
         os.chdir(cwd)
 


### PR DESCRIPTION
Main advantages over nose:

* assertions errors are reported with details on the assertion
* it is much easier to assert raised exceptions, using a `with` statement

Closes #28.