### PR TITLE
Fix bugs for the first Kwik prototype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy
   - source activate testenv
   # Optional dependencies.
-  - conda install matplotlib h5py pyqt ipython-notebook
+  - conda install matplotlib scipy h5py pyqt ipython-notebook
   # Testing dependencies.
   - conda install pytest pip flake8 coverage
   - pip install coveralls

--- a/phy/cluster/manual/session.py
+++ b/phy/cluster/manual/session.py
@@ -66,7 +66,7 @@ class Session(object):
         """Update the session after new data has been loaded."""
         # Update the Selector and Clustering instances using the Model.
         spike_clusters = self.model.spike_clusters
-        self.selector = Selector(spike_clusters, n_spikes_max=None)
+        self.selector = Selector(spike_clusters, n_spikes_max=100)
         self.clustering = Clustering(spike_clusters)
         self.cluster_metadata = self.model.cluster_metadata
         # Reinitialize all existing views.

--- a/phy/datasets/mock.py
+++ b/phy/datasets/mock.py
@@ -11,7 +11,6 @@ import numpy.random as nr
 
 from ..ext import six
 from ..io.base_model import BaseModel
-from ..utils.array import _normalize
 from ..cluster.manual.cluster_metadata import ClusterMetadata
 from ..electrode.mea import MEA, staggered_positions
 
@@ -65,7 +64,6 @@ class MockModel(BaseModel):
         self._metadata = {'description': 'A mock model.'}
         self._cluster_metadata = ClusterMetadata()
         positions = staggered_positions(self.n_channels)
-        positions = _normalize(positions)
         self._probe = MEA(positions=positions)
         self._traces = artificial_traces(self.n_samples_traces,
                                          self.n_channels)

--- a/phy/electrode/mea.py
+++ b/phy/electrode/mea.py
@@ -62,6 +62,14 @@ class MEA(object):
 # Common probes
 #------------------------------------------------------------------------------
 
+def linear_positions(n_channels):
+    """Linear channel positions along the vertical axis."""
+    if n_channels in (0, None):
+        return np.array([[]])
+    return np.c_[np.zeros(n_channels),
+                 np.linspace(0., 1., n_channels)]
+
+
 def staggered_positions(n_channels):
     """Generate channel positions for a staggered probe."""
     i = np.arange(n_channels - 1)

--- a/phy/electrode/tests/test_mea.py
+++ b/phy/electrode/tests/test_mea.py
@@ -9,7 +9,7 @@
 from pytest import raises
 import numpy as np
 
-from ..mea import MEA, staggered_positions
+from ..mea import MEA, linear_positions, staggered_positions
 
 
 #------------------------------------------------------------------------------
@@ -46,6 +46,9 @@ def test_mea():
 
 
 def test_probe():
-    probe = staggered_positions(32)
-    assert probe.shape == (32, 2)
+    probe = staggered_positions(31)
+    assert probe.shape == (31, 2)
     assert np.array_equal(probe[-1], (0, 0))
+
+    probe = linear_positions(29)
+    assert probe.shape == (29, 2)

--- a/phy/io/h5.py
+++ b/phy/io/h5.py
@@ -80,7 +80,12 @@ class File(object):
     def read_attr(self, path, attr_name):
         """Read an attribute of an HDF5 group."""
         _check_hdf5_path(self._h5py_file, path)
-        return self._h5py_file[path].attrs[attr_name]
+        attrs = self._h5py_file[path].attrs
+        if attr_name in attrs:
+            return attrs[attr_name]
+        else:
+            return KeyError("The attribute '{0:s}'".format(attr_name) +
+                            " doesn't exist.")
 
     # Writing functions
     #--------------------------------------------------------------------------

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -303,7 +303,8 @@ class KwikModel(BaseModel):
         self._waveform_loader = WaveformLoader(n_samples=n_samples,
                                                channels=self._channels,
                                                filter=filter,
-                                               filter_margin=order * 3)
+                                               filter_margin=order * 3,
+                                               scale_factor=.01)
 
     @property
     def channels(self):

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -243,17 +243,18 @@ class KwikModel(BaseModel):
             fm = self._kwx.read(path)
             self._features = PartialArray(fm, 0)
 
-            # WARNING: load *all* channel masks in memory for now
             # TODO: sparse, memory mapped, memcache, etc.
             k = self._metadata['nfeatures_per_channel']
-            self._masks = fm[:, 0:k * self.n_channels:k, 1]
+            # This partial array simulates a (n_spikes, n_channels) array.
+            self._masks = PartialArray(fm,
+                                       (slice(0, k * self.n_channels, k), 1))
             assert self._masks.shape == (self.n_spikes, self.n_channels)
 
         self._cluster_metadata = ClusterMetadata()
 
-        # Loading probe.
-        # TODO: load positions.
+        # Load probe.
         positions = self._load_channel_positions()
+
         # TODO: support multiple channel groups.
         self._probe = MEA(positions=positions,
                           n_channels=self.n_channels)

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -15,6 +15,7 @@ from .base_model import BaseModel
 from ..cluster.manual.cluster_metadata import ClusterMetadata
 from .h5 import open_h5, _check_hdf5_path
 from ..waveform.loader import WaveformLoader
+from ..waveform.filter import bandpass_filter, apply_filter
 from ..electrode.mea import MEA, linear_positions
 from ..utils.logging import debug
 
@@ -293,8 +294,14 @@ class KwikModel(BaseModel):
         """Create a waveform loader."""
         n_samples = (self._metadata['extract_s_before'],
                      self._metadata['extract_s_after'])
+        b_filter = bandpass_filter(rate=self._metadata['sample_rate'],
+                                   low=self._metadata['filter_low'],
+                                   high=self._metadata['filter_high'],
+                                   order=self._metadata['filter_butter_order'])
+        filter = lambda x: apply_filter(x, b_filter)
         self._waveform_loader = WaveformLoader(n_samples=n_samples,
-                                               channels=self._channels)
+                                               channels=self._channels,
+                                               filter=filter)
 
     @property
     def channels(self):

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -18,6 +18,7 @@ from ..waveform.loader import WaveformLoader
 from ..waveform.filter import bandpass_filter, apply_filter
 from ..electrode.mea import MEA, linear_positions
 from ..utils.logging import debug
+from ..utils.array import PartialArray
 
 
 #------------------------------------------------------------------------------
@@ -84,28 +85,6 @@ def _kwik_filenames(filename):
     basename, ext = op.splitext(filename)
     return {ext: '{basename}.{ext}'.format(basename=basename, ext=ext)
             for ext in _KWIK_EXTENSIONS}
-
-
-class PartialArray(object):
-    """Proxy to a view of an array, fixing the last dimension."""
-    def __init__(self, arr, col=None):
-        self._arr = arr
-        self._col = col
-        self.dtype = arr.dtype
-
-    @property
-    def shape(self):
-        return self._arr.shape[:-1]
-
-    def __getitem__(self, item):
-        if self._col is None:
-            return self._arr[item]
-        else:
-            if isinstance(item, tuple):
-                item += (self._col,)
-                return self._arr[item]
-            else:
-                return self._arr[item, ..., self._col]
 
 
 class SpikeLoader(object):

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -210,6 +210,10 @@ class KwikModel(BaseModel):
         return '{0:s}/spikes'.format(self._channel_groups_path)
 
     @property
+    def _channels_path(self):
+        return '{0:s}/channels'.format(self._channel_groups_path)
+
+    @property
     def _clusters_path(self):
         return '{0:s}/clusters'.format(self._channel_groups_path)
 
@@ -269,12 +273,21 @@ class KwikModel(BaseModel):
 
         # Loading probe.
         # TODO: load positions.
-        positions = linear_positions(self.n_channels)
+        positions = self._load_channel_positions()
         # TODO: support multiple channel groups.
         self._probe = MEA(positions=positions,
                           n_channels=self.n_channels)
 
         self._create_waveform_loader()
+
+    def _load_channel_positions(self):
+        """Load the channel positions from the kwik file."""
+        positions = []
+        for channel in self.channels:
+            path = '{0:s}/{1:d}'.format(self._channels_path, channel)
+            position = self._kwik.read_attr(path, 'position')
+            positions.append(position)
+        return np.array(positions)
 
     def _create_waveform_loader(self):
         """Create a waveform loader."""

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -15,7 +15,7 @@ from .base_model import BaseModel
 from ..cluster.manual.cluster_metadata import ClusterMetadata
 from .h5 import open_h5, _check_hdf5_path
 from ..waveform.loader import WaveformLoader
-from ..electrode.mea import MEA
+from ..electrode.mea import MEA, linear_positions
 from ..utils.logging import debug
 
 
@@ -269,7 +269,7 @@ class KwikModel(BaseModel):
 
         # Loading probe.
         # TODO: load positions.
-        positions = None
+        positions = linear_positions(self.n_channels)
         # TODO: support multiple channel groups.
         self._probe = MEA(positions=positions,
                           n_channels=self.n_channels)

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -294,14 +294,16 @@ class KwikModel(BaseModel):
         """Create a waveform loader."""
         n_samples = (self._metadata['extract_s_before'],
                      self._metadata['extract_s_after'])
+        order = self._metadata['filter_butter_order']
         b_filter = bandpass_filter(rate=self._metadata['sample_rate'],
                                    low=self._metadata['filter_low'],
                                    high=self._metadata['filter_high'],
-                                   order=self._metadata['filter_butter_order'])
+                                   order=order)
         filter = lambda x: apply_filter(x, b_filter)
         self._waveform_loader = WaveformLoader(n_samples=n_samples,
                                                channels=self._channels,
-                                               filter=filter)
+                                               filter=filter,
+                                               filter_margin=order * 3)
 
     @property
     def channels(self):

--- a/phy/io/tests/test_kwik_model.py
+++ b/phy/io/tests/test_kwik_model.py
@@ -49,9 +49,17 @@ def _create_test_file(dir_path, n_clusters=None, n_spikes=None,
         def _write_metadata(key, value):
             f.write_attr('/application_data/spikedetekt', key, value)
 
-        _write_metadata('nfeatures_per_channel', n_features_per_channel)
+        _write_metadata('sample_rate', 20000.)
+
+        # Filter parameters.
+        _write_metadata('filter_low', 500.)
+        _write_metadata('filter_high', 0.95 * .5 * 20000.)
+        _write_metadata('filter_butter_order', 3)
+
         _write_metadata('extract_s_before', 15)
         _write_metadata('extract_s_after', 25)
+
+        _write_metadata('nfeatures_per_channel', n_features_per_channel)
 
         # Create spike times.
         spike_times = artificial_spike_times(n_spikes).astype(np.int64)

--- a/phy/io/tests/test_kwik_model.py
+++ b/phy/io/tests/test_kwik_model.py
@@ -182,11 +182,9 @@ def test_kwik_open():
         with raises(ValueError):
             kwik.channel_group = 42
 
+        kwik.cluster_metadata
+        kwik.probe
         # Not implemented yet.
-        with raises(NotImplementedError):
-            kwik.cluster_metadata
-        with raises(NotImplementedError):
-            kwik.probe
         with raises(NotImplementedError):
             kwik.save()
 

--- a/phy/plot/tests/test_waveforms.py
+++ b/phy/plot/tests/test_waveforms.py
@@ -16,7 +16,6 @@ from ...utils._color import _random_color
 from ...datasets.mock import (artificial_waveforms, artificial_masks,
                               artificial_spike_clusters)
 from ...electrode.mea import staggered_positions
-from ...utils.array import _normalize
 from ...utils.testing import show_test
 
 
@@ -42,7 +41,6 @@ def _test_waveforms(n_spikes=None, n_clusters=None):
     n_samples = 40
 
     channel_positions = staggered_positions(n_channels)
-    channel_positions = _normalize(channel_positions)
 
     waveforms = artificial_waveforms(n_spikes, n_samples,
                                      n_channels).astype(np.float32)

--- a/phy/plot/waveforms.py
+++ b/phy/plot/waveforms.py
@@ -21,18 +21,6 @@ from ..utils.logging import debug
 
 
 #------------------------------------------------------------------------------
-# Utility functions
-#------------------------------------------------------------------------------
-
-def _default_channel_positions(n_channels):
-    """Default linear channel positions."""
-    if n_channels is None:
-        return np.array([[]])
-    return np.c_[np.zeros(n_channels),
-                 np.linspace(0., 1., n_channels)]
-
-
-#------------------------------------------------------------------------------
 # Waveforms visual
 #------------------------------------------------------------------------------
 
@@ -210,8 +198,6 @@ class Waveforms(Visual):
 
     @channel_positions.setter
     def channel_positions(self, value):
-        if value is None:
-            value = _default_channel_positions(self.n_channels)
         value = _as_array(value)
         self._channel_positions = value
         self._set_to_bake('channel_positions')

--- a/phy/plot/waveforms.py
+++ b/phy/plot/waveforms.py
@@ -21,6 +21,18 @@ from ..utils.logging import debug
 
 
 #------------------------------------------------------------------------------
+# Utility functions
+#------------------------------------------------------------------------------
+
+def _default_channel_positions(n_channels):
+    """Default linear channel positions."""
+    if n_channels is None:
+        return np.array([[]])
+    return np.c_[np.zeros(n_channels),
+                 np.linspace(0., 1., n_channels)]
+
+
+#------------------------------------------------------------------------------
 # Waveforms visual
 #------------------------------------------------------------------------------
 
@@ -198,6 +210,8 @@ class Waveforms(Visual):
 
     @channel_positions.setter
     def channel_positions(self, value):
+        if value is None:
+            value = _default_channel_positions(self.n_channels)
         value = _as_array(value)
         self._channel_positions = value
         self._set_to_bake('channel_positions')

--- a/phy/plot/waveforms.py
+++ b/phy/plot/waveforms.py
@@ -15,7 +15,7 @@ from vispy.visuals import Visual
 from vispy.visuals.shaders import ModularProgram, Function, Variable
 from vispy.visuals.glsl.color import HSV_TO_RGB, RGB_TO_HSV
 
-from ..utils.array import _unique, _as_array, _index_of
+from ..utils.array import _unique, _as_array, _index_of, _normalize
 from ._vispy_utils import PanZoomCanvas
 from ..utils.logging import debug
 
@@ -241,7 +241,9 @@ class Waveforms(Visual):
     def _bake_channel_positions(self):
         # WARNING: channel_positions must be in [0,1] because we have a
         # texture.
-        positions = self.channel_positions.reshape((1, self.n_channels, 2))
+        positions = self.channel_positions.astype(np.float32)
+        positions = _normalize(positions)
+        positions = positions.reshape((1, self.n_channels, -1))
         # Rescale a bit and recenter.
         positions = .1 + .8 * positions
         u_channel_pos = np.dstack((positions,

--- a/phy/utils/array.py
+++ b/phy/utils/array.py
@@ -148,3 +148,35 @@ def data_chunk(data, chunk, with_overlap=False):
         raise ValueError("'chunk' should have 2 or 4 elements, "
                          "not {0:d}".format(len(chunk)))
     return data[i:j, ...]
+
+
+# -----------------------------------------------------------------------------
+# PartialArray
+# -----------------------------------------------------------------------------
+
+class PartialArray(object):
+    """Proxy to a view of an array, allowing selection along the first
+    dimension and fixing the other dimensions."""
+    def __init__(self, arr, trailing_shape=None):
+        self._arr = arr
+        # We ensure trailing_shape is a tuple.
+        if trailing_shape is not None:
+            if not isinstance(trailing_shape, tuple):
+                trailing_shape = (trailing_shape,)
+            self.shape = arr.shape[:-len(trailing_shape)]
+        else:
+            self.shape = arr.shape
+        self._trailing_shape = trailing_shape
+        self.dtype = arr.dtype
+
+    def __getitem__(self, item):
+        if self._trailing_shape is None:
+            return self._arr[item]
+        else:
+            if not isinstance(item, tuple):
+                item = (item,)
+            item += self._trailing_shape
+            if len(item) != len(self._arr.shape):
+                raise ValueError("The array selection is invalid: "
+                                 "{0}".format(str(item)))
+            return self._arr[item]

--- a/phy/utils/array.py
+++ b/phy/utils/array.py
@@ -54,7 +54,7 @@ def _index_of(arr, lookup):
 
 _ACCEPTED_ARRAY_DTYPES = (np.float, np.float32, np.float64,
                           np.int, np.int8, np.int16, np.uint8, np.uint16,
-                          np.int32, np.int64,
+                          np.int32, np.int64, np.uint32, np.uint64,
                           np.bool)
 
 

--- a/phy/utils/tests/test_array.py
+++ b/phy/utils/tests/test_array.py
@@ -11,7 +11,8 @@ from numpy.testing import assert_array_equal as ae
 from pytest import raises
 
 from ..array import (_unique, _normalize, _index_of, _as_array,
-                     chunk_bounds, excerpts, data_chunk, PartialArray)
+                     chunk_bounds, excerpts, data_chunk,
+                     PartialArray, _partial_shape)
 from ...datasets.mock import artificial_spike_clusters
 
 
@@ -113,11 +114,25 @@ def test_excerpts_2():
 # Test PartialArray
 #------------------------------------------------------------------------------
 
+def test_partial_shape():
+    assert _partial_shape((5, 3), 1) == (5,)
+    assert _partial_shape((5, 3), (1,)) == (5,)
+    assert _partial_shape((5, 10, 2), 1) == (5, 10)
+    with raises(ValueError):
+        _partial_shape((5, 10, 2), (1, 2))
+    assert _partial_shape((5, 10, 3), (1, 2)) == (5,)
+    assert _partial_shape((5, 10, 3), (slice(None, None, None), 2)) == (5, 10)
+    assert _partial_shape((5, 10, 3), (slice(1, None, None), 2)) == (5, 9)
+    assert _partial_shape((5, 10, 3), (slice(1, 5, None), 2)) == (5, 4)
+    assert _partial_shape((5, 10, 3), (slice(4, None, 3), 2)) == (5, 2)
+
+
 def test_partial_array():
     # 2D array.
     arr = np.random.rand(5, 2)
 
     pa = PartialArray(arr, 1)
+    assert pa.shape == (5,)
     ae(pa[0], arr[0, 1])
     ae(pa[0:2], arr[0:2, 1])
     ae(pa[[1, 2]], arr[[1, 2], 1])
@@ -128,6 +143,7 @@ def test_partial_array():
     arr = np.random.rand(5, 3, 2)
 
     pa = PartialArray(arr, (2, 1))
+    assert pa.shape == (5,)
     ae(pa[0], arr[0, 2, 1])
     ae(pa[0:2], arr[0:2, 2, 1])
     ae(pa[[1, 2]], arr[[1, 2], 2, 1])
@@ -135,8 +151,18 @@ def test_partial_array():
         pa[[1, 2], 0]
 
     pa = PartialArray(arr, (1,))
+    assert pa.shape == (5, 3)
     ae(pa[0, 2], arr[0, 2, 1])
     ae(pa[0:2, 1], arr[0:2, 1, 1])
     ae(pa[[1, 2], 0], arr[[1, 2], 0, 1])
     with raises(ValueError):
         pa[[1, 2]]
+
+    # Slice and 3D.
+    arr = np.random.rand(5, 10, 2)
+
+    pa = PartialArray(arr, (slice(1, None, 3), 1))
+    assert pa.shape == (5, 3)
+    ae(pa[0], arr[0, 1::3, 1])
+    ae(pa[0:2], arr[0:2, 1::3, 1])
+    ae(pa[[1, 2]], arr[[1, 2], 1::3, 1])

--- a/phy/utils/tests/test_array.py
+++ b/phy/utils/tests/test_array.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_array_equal as ae
 from pytest import raises
 
 from ..array import (_unique, _normalize, _index_of, _as_array,
-                     chunk_bounds, excerpts, data_chunk)
+                     chunk_bounds, excerpts, data_chunk, PartialArray)
 from ...datasets.mock import artificial_spike_clusters
 
 
@@ -107,3 +107,36 @@ def test_excerpts_2():
                                                         n_excerpts=3,
                                                         excerpt_size=10)]
     assert bounds == [(0, 10)]
+
+
+#------------------------------------------------------------------------------
+# Test PartialArray
+#------------------------------------------------------------------------------
+
+def test_partial_array():
+    # 2D array.
+    arr = np.random.rand(5, 2)
+
+    pa = PartialArray(arr, 1)
+    ae(pa[0], arr[0, 1])
+    ae(pa[0:2], arr[0:2, 1])
+    ae(pa[[1, 2]], arr[[1, 2], 1])
+    with raises(ValueError):
+        pa[[1, 2], 0]
+
+    # 3D array.
+    arr = np.random.rand(5, 3, 2)
+
+    pa = PartialArray(arr, (2, 1))
+    ae(pa[0], arr[0, 2, 1])
+    ae(pa[0:2], arr[0:2, 2, 1])
+    ae(pa[[1, 2]], arr[[1, 2], 2, 1])
+    with raises(ValueError):
+        pa[[1, 2], 0]
+
+    pa = PartialArray(arr, (1,))
+    ae(pa[0, 2], arr[0, 2, 1])
+    ae(pa[0:2, 1], arr[0:2, 1, 1])
+    ae(pa[[1, 2], 0], arr[[1, 2], 0, 1])
+    with raises(ValueError):
+        pa[[1, 2]]

--- a/phy/waveform/filter.py
+++ b/phy/waveform/filter.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+"""Waveform filtering routines."""
+
+#------------------------------------------------------------------------------
+# Imports
+#------------------------------------------------------------------------------
+
+import numpy as np
+from scipy import signal
+
+from ..ext import six
+from ..utils.array import _as_array
+
+
+#------------------------------------------------------------------------------
+# Waveform filtering routines
+#------------------------------------------------------------------------------
+
+def bandpass_filter(rate=None, low=None, high=None, order=None):
+    """Butterworth bandpass filter."""
+    return signal.butter(order,
+                         (low/(rate/2.), high/(rate/2.)),
+                         'pass')
+
+
+def apply_filter(x, filter=None):
+    if x.shape[0] == 0:
+        return x
+    b, a = filter
+    try:
+        out_arr = signal.filtfilt(b, a, x, axis=0)
+    except TypeError:
+        out_arr = np.zeros_like(x)
+        for i_ch in range(x.shape[1]):
+            out_arr[:, i_ch] = signal.filtfilt(b, a, x[:, i_ch])
+    return out_arr

--- a/phy/waveform/filter.py
+++ b/phy/waveform/filter.py
@@ -19,6 +19,7 @@ from ..utils.array import _as_array
 
 def bandpass_filter(rate=None, low=None, high=None, order=None):
     """Butterworth bandpass filter."""
+    # TODO: implement in a class instead.
     return signal.butter(order,
                          (low/(rate/2.), high/(rate/2.)),
                          'pass')
@@ -28,10 +29,4 @@ def apply_filter(x, filter=None):
     if x.shape[0] == 0:
         return x
     b, a = filter
-    try:
-        out_arr = signal.filtfilt(b, a, x, axis=0)
-    except TypeError:
-        out_arr = np.zeros_like(x)
-        for i_ch in range(x.shape[1]):
-            out_arr[:, i_ch] = signal.filtfilt(b, a, x[:, i_ch])
-    return out_arr
+    return signal.filtfilt(b, a, x, axis=0)

--- a/phy/waveform/loader.py
+++ b/phy/waveform/loader.py
@@ -153,6 +153,7 @@ class WaveformLoader(object):
             extract = _pad(extract, self.n_samples_waveforms, 'right')
 
         # Filter the waveforms.
+        # TODO: do the filtering in a vectorized way for more performance.
         if self._filter is not None:
             waveforms = self._filter(extract)
         else:

--- a/phy/waveform/loader.py
+++ b/phy/waveform/loader.py
@@ -43,6 +43,9 @@ def _slice(index, n_samples, margin=None):
     margin_before, margin_after = margin
     before += margin_before
     after += margin_after
+    index = int(index)
+    before = int(before)
+    after = int(after)
     return slice(max(0, index - before), index + after, None)
 
 

--- a/phy/waveform/loader.py
+++ b/phy/waveform/loader.py
@@ -89,12 +89,14 @@ class WaveformLoader(object):
 
     def __init__(self, traces=None, offset=0, filter=None,
                  n_samples=None, filter_margin=0,
-                 channels=None):
+                 channels=None, scale_factor=None):
         # A (possibly memmapped) array-like structure with traces.
         if traces is not None:
             self.traces = traces
         else:
             self._traces = None
+        # Scale factor for the loaded waveforms.
+        self._scale_factor = scale_factor
         # Offset of the traces: time (in samples) of the first trace sample.
         self._offset = int(offset)
         # List of channels to use when loading the waveforms.
@@ -193,4 +195,6 @@ class WaveformLoader(object):
         # Load all spikes.
         for i, time in enumerate(spikes):
             waveforms[i, ...] = self._load_at(time)
+        if self._scale_factor is not None:
+            waveforms *= self._scale_factor
         return waveforms

--- a/phy/waveform/loader.py
+++ b/phy/waveform/loader.py
@@ -96,7 +96,7 @@ class WaveformLoader(object):
         else:
             self._traces = None
         # Offset of the traces: time (in samples) of the first trace sample.
-        self._offset = 0
+        self._offset = int(offset)
         # List of channels to use when loading the waveforms.
         self._channels = channels
         # A filter function that takes a (n_samples, n_channels) array as
@@ -137,6 +137,7 @@ class WaveformLoader(object):
 
     def _load_at(self, time):
         """Load a waveform at a given time."""
+        time = int(time)
         time_o = time - self._offset
         if not (0 <= time_o < self.n_samples_trace):
             raise ValueError("Invalid time {0:d}.".format(time_o))

--- a/phy/waveform/tests/test_filter.py
+++ b/phy/waveform/tests/test_filter.py
@@ -1,0 +1,36 @@
+
+# -*- coding: utf-8 -*-
+
+"""Tests of waveform filtering routines."""
+
+#------------------------------------------------------------------------------
+# Imports
+#------------------------------------------------------------------------------
+
+import numpy as np
+
+from ..filter import bandpass_filter, apply_filter
+
+
+#------------------------------------------------------------------------------
+# Tests
+#------------------------------------------------------------------------------
+
+def test_apply_filter():
+    """Test bandpass filtering on a combination of two sinusoids."""
+
+    rate = 10000.
+    low, high = 100., 200.
+
+    # Create a signal with small and high frequencies.
+    t = np.linspace(0., 1., rate)
+    x = np.sin(2 * np.pi * low / 2 * t) + np.cos(2 * np.pi * high * 2 * t)
+
+    # Filter the signal.
+    filter = bandpass_filter(low=low, high=high, order=4, rate=rate)
+    x_filtered = apply_filter(x, filter=filter)
+
+    # Check that the bandpass-filtered signal is weak.
+    k = int(2. / low * rate)
+    assert np.abs(x[k:-k]).max() >= .9
+    assert np.abs(x_filtered[k:-k]).max() <= .1

--- a/phy/waveform/tests/test_loader.py
+++ b/phy/waveform/tests/test_loader.py
@@ -76,6 +76,10 @@ def test_loader_channels():
     assert loader[500].shape == (1, n_samples, 3)
     assert loader[[500, 501, 600, 300]].shape == (4, n_samples, 3)
 
+    # Test edge effects.
+    assert loader[3].shape == (1, n_samples, 3)
+    assert loader[995].shape == (1, n_samples, 3)
+
     with raises(NotImplementedError):
         loader[500:510]
 


### PR DESCRIPTION
* [x] Fixed edge effects in waveform loader, using a `_pad()` function.
* [x] Added `linear_positions()` probe positions.
* [x] Put normalization of channel positions in the waveform view.
* [x] Limit the number of waveforms to show
* [x] Add the filter in the waveform loader
* [x] In waveform view, auto-compute the scale
* [x] Do not load the masks in memory but provide an array proxy

Closes #40.