### PR TITLE
Make WaveformView work in WebGL

### DIFF
--- a/phy/cluster/manual/cluster_info.py
+++ b/phy/cluster/manual/cluster_info.py
@@ -98,9 +98,6 @@ class ClusterMetadata(object):
         # Create self.set_<field>(clusters, value).
         setattr(self, 'set_{0:s}'.format(field),
                 lambda clusters, value: self._set(clusters, field, value))
-        # def wrapped(cluster):
-        #     default = func(cluster)
-        #     return default
         return func
 
     def undo(self):
@@ -125,15 +122,6 @@ class ClusterMetadata(object):
         self._set(clusters, field, value, add_to_stack=False)
         # Return the UpdateInfo instance of the redo action.
         return info
-
-    def keys(self):
-        return self._data.keys()
-
-    def values(self):
-        return self._data.values()
-
-    def items(self):
-        return self._data.items()
 
 
 #------------------------------------------------------------------------------

--- a/phy/cluster/manual/cluster_info.py
+++ b/phy/cluster/manual/cluster_info.py
@@ -89,7 +89,7 @@ class ClusterMetadata(object):
             self._undo_stack.add((clusters, field, value, info))
         return info
 
-    def field(self, func):
+    def default(self, func):
         field = func.__name__
         # Register the decorated function as the default field function.
         self._fields[field] = func

--- a/phy/cluster/manual/interface.py
+++ b/phy/cluster/manual/interface.py
@@ -31,7 +31,7 @@ def _mean_masks(masks, spikes):
     return masks[spikes].mean(axis=0)
 
 
-def create_clustering_session(filename=None, model=None):
+def create_clustering_session(filename=None, model=None, backend=None):
     """Create a manual clustering session in the IPython notebook.
 
     Parameters
@@ -123,7 +123,11 @@ def create_clustering_session(filename=None, model=None):
 
     @session.action(title='Show waveforms')
     def show_waveforms():
-        view = WaveformView()
+        if backend in ('pyqt4', None):
+            kwargs = {'always_on_top': True}
+        else:
+            kwargs = {}
+        view = WaveformView(**kwargs)
 
         @session.connect
         def on_open():
@@ -185,7 +189,8 @@ def create_clustering_session(filename=None, model=None):
     return session
 
 
-def start_manual_clustering(filename=None, model=None, session=None):
+def start_manual_clustering(filename=None, model=None, session=None,
+                            backend=None):
     """Start a manual clustering session in the IPython notebook.
 
     Parameters
@@ -200,10 +205,11 @@ def start_manual_clustering(filename=None, model=None, session=None):
     """
 
     if session is None:
-        session = create_clustering_session(filename=filename, model=model)
+        session = create_clustering_session(filename=filename, model=model,
+                                            backend=backend)
 
     # Enable the notebook interface.
-    enable_notebook()
+    enable_notebook(backend=backend)
 
     session.open(filename=filename, model=model)
     session.show_clusters()

--- a/phy/cluster/manual/interface.py
+++ b/phy/cluster/manual/interface.py
@@ -169,7 +169,6 @@ def create_clustering_session(filename=None, model=None):
 
         cluster_colors = [session.cluster_metadata.color(cluster)
                           for cluster in session.clustering.cluster_labels]
-
         try:
             view = ClusterView(clusters=session.clustering.cluster_labels,
                                colors=cluster_colors)

--- a/phy/cluster/manual/tests/test_cluster_info.py
+++ b/phy/cluster/manual/tests/test_cluster_info.py
@@ -20,11 +20,11 @@ from ..cluster_info import (ClusterMetadata,
 def test_cluster_metadata():
     meta = ClusterMetadata()
 
-    @meta.field
+    @meta.default
     def group(cluster):
         return 3
 
-    @meta.field
+    @meta.default
     def color(cluster):
         return 0
 
@@ -60,11 +60,11 @@ def test_metadata_history():
 
     meta = ClusterMetadata(data=data)
 
-    @meta.field
+    @meta.default
     def group(cluster):
         return 3
 
-    @meta.field
+    @meta.default
     def color(cluster):
         return 0
 

--- a/phy/io/h5.py
+++ b/phy/io/h5.py
@@ -176,12 +176,14 @@ class File(object):
     def groups(self, path='/'):
         """Return the list of groups under a given node."""
         return [key for key in self.children(path)
-                if isinstance(self._h5py_file[key], h5py.Group)]
+                if isinstance(self._h5py_file[path + '/' + key],
+                              h5py.Group)]
 
     def datasets(self, path='/'):
         """Return the list of datasets under a given node."""
         return [key for key in self.children(path)
-                if isinstance(self._h5py_file[key], h5py.Dataset)]
+                if isinstance(self._h5py_file[path + '/' + key],
+                              h5py.Dataset)]
 
     def _print_node_info(self, name, node):
         """Print node information."""

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -253,11 +253,11 @@ class KwikModel(BaseModel):
 
         self._cluster_metadata = ClusterMetadata()
 
-        @self._cluster_metadata.field
+        @self._cluster_metadata.default
         def color(cluster):
             return _random_color()
 
-        @self._cluster_metadata.field
+        @self._cluster_metadata.default
         def group(cluster):
             return 3
 

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -407,7 +407,6 @@ class KwikModel(BaseModel):
     @property
     def _clusters(self):
         """List of clusters in the Kwik file."""
-        print(self._clustering_path)
         clusters = self._kwik.groups(self._clustering_path)
         clusters = [int(cluster) for cluster in clusters]
         return sorted(clusters)

--- a/phy/io/kwik_model.py
+++ b/phy/io/kwik_model.py
@@ -307,7 +307,7 @@ class KwikModel(BaseModel):
             path = (self._clustering_path + '/' + str(cluster) +
                     '/application_data/klustaviewa')
             color_int = self._kwik.read_attr(path, 'color')
-            return _COLOR_MAP[color_int]
+            return tuple(_COLOR_MAP[color_int])
 
         colors = {cluster: {'color': _get_color(cluster)}
                   for cluster in self._clusters}

--- a/phy/io/mock/artificial.py
+++ b/phy/io/mock/artificial.py
@@ -65,7 +65,7 @@ class MockModel(BaseModel):
         self._metadata = {'description': 'A mock model.'}
         self._cluster_metadata = ClusterMetadata()
 
-        @self._cluster_metadata.field
+        @self._cluster_metadata.default
         def color(cluster):
             return _random_color()
 

--- a/phy/plot/tests/test_waveforms.py
+++ b/phy/plot/tests/test_waveforms.py
@@ -47,9 +47,11 @@ def _test_waveforms(n_spikes=None, n_clusters=None):
     masks = artificial_masks(n_spikes, n_channels).astype(np.float32)
     spike_clusters = artificial_spike_clusters(n_spikes, n_clusters)
 
-    metadata = {cluster: {'color': _random_color()}
-                for cluster in range(n_clusters)}
-    cluster_metadata = ClusterMetadata(metadata)
+    cluster_metadata = ClusterMetadata()
+
+    @cluster_metadata.default
+    def color(cluster):
+        return _random_color()
 
     c = WaveformView()
     c.visual.waveforms = waveforms

--- a/phy/plot/waveforms.py
+++ b/phy/plot/waveforms.py
@@ -216,7 +216,7 @@ class Waveforms(Visual):
         """Colors of the displayed clusters."""
         clusters = self.cluster_labels
         return np.array([self._cluster_metadata.color(cluster)
-                         for cluster in clusters], dtype=np.float32)
+                         for cluster in clusters])
 
     @property
     def box_scale(self):
@@ -233,7 +233,7 @@ class Waveforms(Visual):
 
     def _bake_metadata(self):
         u_cluster_color = self.cluster_colors.reshape((1, self.n_clusters, -1))
-        u_cluster_color = u_cluster_color.astype(np.float32)
+        u_cluster_color = (u_cluster_color * 255).astype(np.uint8)
         # TODO: more efficient to update the data from an existing texture
         self.program['u_cluster_color'] = Texture2D(u_cluster_color)
         debug("bake color", u_cluster_color.shape)
@@ -248,7 +248,7 @@ class Waveforms(Visual):
         positions = .1 + .8 * positions
         u_channel_pos = np.dstack((positions,
                                   np.zeros((1, self.n_channels, 1))))
-        u_channel_pos = u_channel_pos.astype(np.float32)
+        u_channel_pos = (u_channel_pos * 255).astype(np.uint8)
         # TODO: more efficient to update the data from an existing texture
         self.program['u_channel_pos'] = Texture2D(u_channel_pos,
                                                   wrapping='clamp_to_edge')

--- a/phy/plot/waveforms.py
+++ b/phy/plot/waveforms.py
@@ -331,7 +331,6 @@ class Waveforms(Visual):
 
 class WaveformView(PanZoomCanvas):
     def __init__(self, **kwargs):
-        kwargs['always_on_top'] = True
         super(WaveformView, self).__init__(**kwargs)
         self.visual = Waveforms()
 


### PR DESCRIPTION
* Use uint8 textures instead of float32 for better compatibility
* Added old KlustaViewa colormap
* Renamed `field` to `default` in cluster metadata decorator
* Load cluster metadata in kwik
* Added backend option in the interface for VisPy