### PR TITLE
[MRG] Save KK2 iteration

### DIFF
--- a/phy/cluster/algorithms.py
+++ b/phy/cluster/algorithms.py
@@ -737,9 +737,10 @@ class SpikeDetekt(EventEmitter):
 # Clustering class
 #------------------------------------------------------------------------------
 
-class KlustaKwik(object):
+class KlustaKwik(EventEmitter):
     """KlustaKwik automatic clustering algorithm."""
     def __init__(self, **kwargs):
+        super(KlustaKwik, self).__init__()
         self._kwargs = kwargs
         self.__dict__.update(kwargs)
         # Set the version.
@@ -769,6 +770,11 @@ class KlustaKwik(object):
         # Run KK.
         from klustakwik2 import KK
         kk = KK(data, **self._kwargs)
+
+        @kk.register_callback
+        def f(_):
+            self.emit('iter', kk.clusters)
+
         self.params = kk.all_params
         kk.cluster_mask_starts()
         spike_clusters = kk.clusters

--- a/phy/cluster/tests/test_session.py
+++ b/phy/cluster/tests/test_session.py
@@ -373,7 +373,8 @@ def test_session_auto(session, spike_ids):
                          clustering='test',
                          )
     assert session.model.clustering == 'test'
-    assert session.model.clusterings == ['main', 'original', 'test']
+    assert session.model.clusterings == ['main', 'kk2_current',
+                                         'original', 'test']
 
     # Re-open the dataset and check that the clustering has been saved.
     session = _start_manual_clustering(kwik_path=session.model.path,
@@ -385,10 +386,13 @@ def test_session_auto(session, spike_ids):
 
     assert 'klustakwik_version' not in session.model.clustering_metadata
 
-    session.change_clustering('test')
-    assert len(session.model.spike_clusters) == n_spikes
-    assert np.all(session.model.spike_clusters[spike_ids] == sc)
+    for clustering in ('test', 'kk2_current'):
+        session.change_clustering(clustering)
+        assert len(session.model.spike_clusters) == n_spikes
+        assert np.all(session.model.spike_clusters[spike_ids] == sc)
 
+    # Test clustering metadata.
+    session.change_clustering('test')
     metadata = session.model.clustering_metadata
     assert 'klustakwik_version' in metadata
     assert metadata['klustakwik_num_starting_clusters'] == 10


### PR DESCRIPTION
Closes #501.

@nsteinme this saves the latest KK2 iteration in a new clustering name `kk2_current`. Due to a limitation in the file format (another one), the current active clustering cannot be changed, and it is just simpler to save it in a separate clustering.

The `KwikModel` implements several methods to manage different clusterings in the same `.kwik` file (add, remove, copy, rename, etc.).