### PR TITLE
[MRG] Better handling of traces

### DIFF
--- a/phy/io/kwik/model.py
+++ b/phy/io/kwik/model.py
@@ -570,8 +570,20 @@ class KwikModel(BaseModel):
     def open(self, kwik_path, channel_group=None, clustering=None):
         """Open a Kwik dataset.
 
-        The `.kwik`, `.kwx`, and `.raw.kwd` must be in the same folder with the
+        The `.kwik` and `.kwx` must be in the same folder with the
         same basename.
+
+        The files containing the traces (`.raw.kwd` or `.dat` / `.bin`) are
+        determined according to the following logic:
+
+        - Is there a path specified in to a file which exists in [KWIK]/recordings/[X]/raw?
+        If so, open it.
+        - If this file does not exist, does a file exist with the same name in the current
+        directory? If so, open it.
+        - If such a file does not exist, or no filename is specified in the [KWIK], then
+        is there a `.dat`, `.bin, or .`raw.kwd` with the experiment basename in the current
+        directory? If so, open it.
+        - If not, return with a warning.
 
         Notes
         -----
@@ -584,8 +596,8 @@ class KwikModel(BaseModel):
 
         The `.kwx` and `.raw.kwd` files stay open in read-only mode as long
         as `model.close()` is not called. This is because there might be
-        read accesses to `features_masks` (`.kwx`) and waveforms (`.raw.kwd`)
-        while the dataset is opened.
+        read accesses to `features_masks` (`.kwx`) and waveforms (`.raw.kwd`
+        or `.dat` / `.bin`) while the dataset is opened.
 
         Parameters
         ----------
@@ -626,8 +638,7 @@ class KwikModel(BaseModel):
                  "Features and masks won't be available.")
         self._kwd = _open_h5_if_exists(kwik_path, 'raw.kwd')
         if self._kwd is None:
-            debug("The `.raw.kwd` file hasn't been found. "
-                  "Traces and waveforms won't be available.")
+            debug("No `.raw.kwd` file has been found.")
 
         # KwikCreator instance.
         self.creator = KwikCreator(kwik_path=kwik_path)

--- a/phy/io/kwik/model.py
+++ b/phy/io/kwik/model.py
@@ -174,7 +174,7 @@ def _open_h5_if_exists(kwik_path, file_type, mode=None):
     return open_h5(path, mode=mode) if op.exists(path) else None
 
 
-def _read_traces(kwik, kwik_path, dtype=None, n_channels=None):
+def _read_traces(kwik, dtype=None, n_channels=None):
     kwd_path = None
     dat_path = None
     if '/recordings' not in kwik:
@@ -245,7 +245,7 @@ def _read_traces(kwik, kwik_path, dtype=None, n_channels=None):
 
         # Finally, is there a `raw.kwd` with the experiment basename in the
         # current directory? If so, open it.
-        kwd = _open_h5_if_exists(kwik_path, '.raw.kwd')
+        kwd = _open_h5_if_exists(kwik.filename, '.raw.kwd')
         if kwd is None:
             warn("Could not find any data source for traces (raw.kwd or "
                  ".dat or .bin.) Waveforms and traces will not be available.")
@@ -591,7 +591,6 @@ class KwikModel(BaseModel):
         dtype = self._metadata.get('dtype', None)
         dtype = np.dtype(dtype) if dtype else None
         traces = _read_traces(self._kwik,
-                              self.kwik_path,
                               dtype=dtype,
                               n_channels=n_channels)
         if not traces:

--- a/phy/io/kwik/model.py
+++ b/phy/io/kwik/model.py
@@ -178,7 +178,7 @@ def _read_traces(kwik, dtype=None, n_channels=None):
     kwd_path = None
     dat_path = None
     if '/recordings' not in kwik:
-        return
+        return (None, None)
     recordings = kwik.children('/recordings')
     traces = []
     opened_files = []
@@ -1209,8 +1209,14 @@ class KwikModel(BaseModel):
     def close(self):
         """Close the `.kwik` and `.kwx` files if they are open, and cleanup
         handles to all raw data files"""
+
+        debug("Closing files")
         if self._kwx is not None:
             self._kwx.close()
         for f in self._opened_files:
-            f.close()
+            # upside-down if statement to avoid false positive lint error
+            if not (isinstance(f, np.ndarray)):
+                f.close()
+            else:
+                del f
         self._kwik.close()

--- a/phy/io/kwik/model.py
+++ b/phy/io/kwik/model.py
@@ -175,6 +175,8 @@ def _open_h5_if_exists(kwik_path, file_type, mode=None):
 
 
 def _read_traces(kwik, kwik_path, dtype=None, n_channels=None):
+    kwd_path = None
+    dat_path = None
     if '/recordings' not in kwik:
         return
     recordings = kwik.children('/recordings')
@@ -190,6 +192,8 @@ def _read_traces(kwik, kwik_path, dtype=None, n_channels=None):
                 debug("{} not found, trying same basename in KWIK dir"
                       .format(kwd_path))
             else:
+                debug("Loading traces: {}"
+                      .format(kwd_path))
                 traces.append(kwd.read('/recordings/{}/data'
                               .format(recording)))
                 continue
@@ -202,6 +206,8 @@ def _read_traces(kwik, kwik_path, dtype=None, n_channels=None):
                 debug("{} not found, trying same basename in KWIK dir"
                       .format(dat_path))
             else:
+                debug("Loading traces: {}"
+                      .format(dat_path))
                 traces.append(_dat_to_traces(dat_path, dtype=dtype,
                                              n_channels=n_channels))
                 continue
@@ -217,6 +223,8 @@ def _read_traces(kwik, kwik_path, dtype=None, n_channels=None):
                 debug("{} not found, trying experiment basename in KWIK dir"
                       .format(rel_path))
             else:
+                debug("Loading traces: {}"
+                      .format(rel_path))
                 traces.append(kwd.read('/recordings/{}/data'
                               .format(recording)))
                 continue
@@ -224,11 +232,14 @@ def _read_traces(kwik, kwik_path, dtype=None, n_channels=None):
             rel_path = op.basename(dat_path)
             rel_path = op.join(op.dirname(op.realpath(kwik.filename)),
                                rel_path)
-            if not op.exists(dat_path):
+            print('rel_path', rel_path)
+            if not op.exists(rel_path):
                 debug("{} not found, trying experiment basename in KWIK dir"
                       .format(rel_path))
             else:
-                traces.append(_dat_to_traces(dat_path, dtype=dtype,
+                debug("Loading traces: {}"
+                      .format(rel_path))
+                traces.append(_dat_to_traces(rel_path, dtype=dtype,
                                              n_channels=n_channels))
                 continue
 
@@ -628,10 +639,11 @@ class KwikModel(BaseModel):
 
         The `.kwik` file is temporarily opened in append mode when saving.
 
-        The `.kwx` and `.raw.kwd` files stay open in read-only mode as long
-        as `model.close()` is not called. This is because there might be
-        read accesses to `features_masks` (`.kwx`) and waveforms (`.raw.kwd`
-        or `.dat` / `.bin`) while the dataset is opened.
+        The `.kwx` and `.raw.kwd` or `.dat` / `.bin` files stay open in
+        read-only mode as long as `model.close()` is not called. This is
+        because there might be read accesses to `features_masks` (`.kwx`)
+        and waveforms (`.raw.kwd` or `.dat` / `.bin`) while the dataset is
+        opened.
 
         Parameters
         ----------

--- a/phy/io/kwik/model.py
+++ b/phy/io/kwik/model.py
@@ -232,7 +232,6 @@ def _read_traces(kwik, dtype=None, n_channels=None):
             rel_path = op.basename(dat_path)
             rel_path = op.join(op.dirname(op.realpath(kwik.filename)),
                                rel_path)
-            print('rel_path', rel_path)
             if not op.exists(rel_path):
                 debug("{} not found, trying experiment basename in KWIK dir"
                       .format(rel_path))
@@ -245,11 +244,12 @@ def _read_traces(kwik, dtype=None, n_channels=None):
 
         # Finally, is there a `raw.kwd` with the experiment basename in the
         # current directory? If so, open it.
-        kwd = _open_h5_if_exists(kwik.filename, '.raw.kwd')
+        kwd = _open_h5_if_exists(kwik.filename, 'raw.kwd')
         if kwd is None:
             warn("Could not find any data source for traces (raw.kwd or "
                  ".dat or .bin.) Waveforms and traces will not be available.")
         else:
+            debug("Successfully loaded basename.raw.kwd in same directory")
             traces.append(kwd.read('/recordings/{}/data'.format(recording)))
 
     return traces

--- a/phy/io/traces.py
+++ b/phy/io/traces.py
@@ -63,6 +63,7 @@ def read_dat(filename, dtype=None, shape=None, offset=0, n_channels=None):
     return np.memmap(filename, dtype=dtype, shape=shape,
                      mode='r', offset=offset)
 
+
 def _dat_to_traces(dat_path, n_channels, dtype):
     assert dtype is not None
     assert n_channels is not None
@@ -73,6 +74,7 @@ def _dat_to_traces(dat_path, n_channels, dtype):
     return read_dat(dat_path,
                     dtype=dtype,
                     shape=(n_samples, n_channels))
+
 
 def _dat_n_samples(filename, dtype=None, n_channels=None):
     assert dtype is not None

--- a/phy/io/traces.py
+++ b/phy/io/traces.py
@@ -63,6 +63,16 @@ def read_dat(filename, dtype=None, shape=None, offset=0, n_channels=None):
     return np.memmap(filename, dtype=dtype, shape=shape,
                      mode='r', offset=offset)
 
+def _dat_to_traces(dat_path, n_channels, dtype):
+    assert dtype is not None
+    assert n_channels is not None
+    n_samples = _dat_n_samples(dat_path,
+                               n_channels=n_channels,
+                               dtype=dtype,
+                               )
+    return read_dat(dat_path,
+                    dtype=dtype,
+                    shape=(n_samples, n_channels))
 
 def _dat_n_samples(filename, dtype=None, n_channels=None):
     assert dtype is not None


### PR DESCRIPTION
Closes #602 
Closes #592 
Closes #590 
Finally fixes #488 and #437 properly!

Traces-opening logic is now (as per docstring)
        
> The `.kwik` and `.kwx` must be in the same folder with the same basename.

> The files containing the traces (`.raw.kwd` or `.dat` / `.bin`) are determined according to the following logic:

> - Is there a path specified to a file which exists in [KWIK]/recordings/[X]/raw? If so, open it.
> - If this file does not exist, does a file exist with the same name in the current directory? If so, open it.
> - If such a file does not exist, or no filename is specified in the [KWIK], then is there a `raw.kwd` with the experiment basename in the current directory? If so, open it.
> - If not, return with a warning.