### PR TITLE
[MRG] fix #581 and fix #620

### DIFF
--- a/phy/io/kwik/model.py
+++ b/phy/io/kwik/model.py
@@ -726,7 +726,7 @@ class KwikModel(BaseModel):
         self._channel_group_changed(self._channel_group)
 
         # This loads spike clusters and cluster groups.
-        self._clustering_changed(self._clustering)
+        self._clustering_changed(clustering)
 
         # This needs channels, channel_order, and waveform loader.
         self._update_waveform_loader()

--- a/phy/io/kwik/model.py
+++ b/phy/io/kwik/model.py
@@ -777,13 +777,20 @@ class KwikModel(BaseModel):
         if value not in self.channel_groups:
             raise ValueError("The channel group {0} is invalid.".format(value))
         self._channel_group = value
+        self.clustering = 'main'
 
         # Load data.
         _to_close = self._open_kwik_if_needed()
+        self._load_clusterings('main')
         self._probe.change_channel_group(value)
         self._load_channels()
         self._load_spikes()
         self._load_features_masks()
+
+        # Recalculate spikes_per_cluster manually
+        self._spikes_per_cluster = \
+            _spikes_per_cluster(self.spike_ids, self._spike_clusters)
+
         if _to_close:
             self._kwik.close()
 

--- a/phy/io/kwik/model.py
+++ b/phy/io/kwik/model.py
@@ -777,11 +777,25 @@ class KwikModel(BaseModel):
         if value not in self.channel_groups:
             raise ValueError("The channel group {0} is invalid.".format(value))
         self._channel_group = value
-        self.clustering = 'main'
 
         # Load data.
         _to_close = self._open_kwik_if_needed()
-        self._load_clusterings('main')
+
+        if self._kwik.h5py_file:
+            clusterings = _list_clusterings(self._kwik.h5py_file,
+                                            self._channel_group)
+        else:
+            warn(".kwik filepath doesn't exist.")
+            clusterings = None
+
+        if clusterings:
+            if 'main' in clusterings:
+                self._load_clusterings('main')
+                self.clustering = 'main'
+            else:
+                self._load_clusterings(clusterings[0])
+                self.clustering = clusterings[0]
+
         self._probe.change_channel_group(value)
         self._load_channels()
         self._load_spikes()

--- a/phy/session/session.py
+++ b/phy/session/session.py
@@ -209,6 +209,7 @@ class Session(BaseSession):
 
     def change_channel_group(self, channel_group):
         """Change the current channel group."""
+        self._channel_group = channel_group
         self.model.channel_group = channel_group
         info("Switched to channel group {}.".format(channel_group))
         self.emit('open')


### PR DESCRIPTION
* Fixes #581 
* Fixes #620

Note that when showing a GUI with a new clustering/shank you need to use `session.show_gui()` to create and load a new GUI rather than `gui.show()` which will try and show the old one with disastrous results...