### PR TITLE
Fix #669

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	flake8 phy
 
 test: lint
-	python setup.py test
+	py.test
 
 coverage:
 	coverage --html
@@ -38,17 +38,3 @@ unit-tests: lint
 integration-tests: lint
 	python setup.py test -a tests
 
-apidoc:
-	python tools/api.py
-
-build:
-	python setup.py sdist --formats=zip
-
-upload:
-	python setup.py sdist --formats=zip upload
-
-release-test:
-	python tools/release.py release_test
-
-release:
-	python tools/release.py release

--- a/phy/detect/spikedetekt.py
+++ b/phy/detect/spikedetekt.py
@@ -195,9 +195,11 @@ class SpikeDetekt(EventEmitter):
 
     def _create_detector(self):
         graph = self._kwargs['probe_adjacency_list']
+        probe_channels = self._kwargs['probe_channels']
         join_size = self._kwargs['connected_component_join_size']
         return FloodFillDetector(probe_adjacency_list=graph,
                                  join_size=join_size,
+                                 channels_per_group=probe_channels,
                                  )
 
     def _create_extractor(self, thresholds):

--- a/phy/traces/detect.py
+++ b/phy/traces/detect.py
@@ -200,8 +200,8 @@ def connected_components(weak_crossings=None,
     # If the channels aren't referenced at all but exist in 'channels', add a
     # trivial self-connection so temporal floodfill will work. If this channel
     # is dead, it should be removed from 'channels'
-    probe_adjacency_list = {i for i in channels
-                            if not probe_adjacency_list.get(i, None)}
+    probe_adjacency_list.update({i: {i} for i in channels
+                                if not probe_adjacency_list.get(i)})
 
     # Make sure the values are sets.
     probe_adjacency_list = {c: set(cs)

--- a/phy/traces/detect.py
+++ b/phy/traces/detect.py
@@ -194,6 +194,9 @@ def connected_components(weak_crossings=None,
     if probe_adjacency_list is None:
         probe_adjacency_list = {}
 
+    if channels is None:
+        channels = []
+
     # If the channels aren't referenced at all but exist in 'channels', add a
     # trivial self-connection so temporal floodfill will work. If this channel
     # is dead, it should be removed from 'channels'

--- a/phy/traces/detect.py
+++ b/phy/traces/detect.py
@@ -199,7 +199,7 @@ def connected_components(weak_crossings=None,
 
     # If the channels aren't referenced at all but exist in 'channels', add a
     # trivial self-connection so temporal floodfill will work. If this channel
-    # is dead, it should be removed from 'channels'
+    # is dead, it should be removed from 'channels'.
     probe_adjacency_list.update({i: {i} for i in channels
                                 if not probe_adjacency_list.get(i)})
 

--- a/phy/traces/detect.py
+++ b/phy/traces/detect.py
@@ -200,9 +200,8 @@ def connected_components(weak_crossings=None,
     # If the channels aren't referenced at all but exist in 'channels', add a
     # trivial self-connection so temporal floodfill will work. If this channel
     # is dead, it should be removed from 'channels'
-    for i in channels:
-        if not probe_adjacency_list.get(i):
-            probe_adjacency_list[i] = {i}
+    probe_adjacency_list = {i for i in channels
+                            if not probe_adjacency_list.get(i, None)}
 
     # Make sure the values are sets.
     probe_adjacency_list = {c: set(cs)

--- a/phy/traces/tests/test_detect.py
+++ b/phy/traces/tests/test_detect.py
@@ -294,3 +294,28 @@ def test_flood_fill():
              ]
     cc = ff(weak, strong)
     _assert_components_equal(cc, comps)
+
+    channels = {0: [1, 2, 3, 4]}
+
+    ff = FloodFillDetector(probe_adjacency_list=graph,
+                           join_size=2,
+                           channels_per_group=channels
+                           )
+
+    weak = [[0, 0, 0, 0, 0],
+            [0, 1, 0, 1, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0],
+            ]
+
+    comps = [[(1, 1)],
+             [(1, 3)],
+             [(4, 4), (6, 4)],
+             ]
+
+    cc = ff(weak, weak)
+    _assert_components_equal(cc, comps)

--- a/phy/traces/tests/test_detect.py
+++ b/phy/traces/tests/test_detect.py
@@ -251,8 +251,11 @@ def test_flood_fill():
 
     graph = {0: [1, 2], 1: [0, 2], 2: [0, 1], 3: []}
 
+    channels = {0: [1, 2, 3]}
+
     ff = FloodFillDetector(probe_adjacency_list=graph,
                            join_size=1,
+                           channels_per_group=channels
                            )
 
     weak = [[0, 0, 0, 0],

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,5 @@ universal = 1
 
 [pytest]
 addopts = --cov-report term-missing --cov phy -s
-
 [flake8]
 ignore=E265

--- a/setup.py
+++ b/setup.py
@@ -10,37 +10,14 @@
 
 import os
 import os.path as op
-import sys
 import re
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 
 #------------------------------------------------------------------------------
 # Setup
 #------------------------------------------------------------------------------
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "String of arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = '--cov-report term-missing --cov=phy phy tests'
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
-        import pytest
-        pytest_string = '-s ' + self.pytest_args
-        print("Running: py.test " + pytest_string)
-        errno = pytest.main(pytest_string)
-        sys.exit(errno)
-
 
 def _package_tree(pkgroot):
     path = op.dirname(__file__)
@@ -81,7 +58,6 @@ setup(
         ],
     },
     include_package_data=True,
-    # zip_safe=False,
     keywords='phy,data analysis,electrophysiology,neuroscience',
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -94,5 +70,4 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
     ],
-    cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
This manually adds trivial connectivity graphs into the FloodFillDetector by passing a `channels` attribute into the `connected_components()` method,  fixing issue #669 where having a null adjacency graph, or leaving a channel out, results in no temporal floodfill being carried out.