### PR TITLE
CLI enhancements

### DIFF
--- a/phy/__init__.py
+++ b/phy/__init__.py
@@ -18,6 +18,7 @@ from .io.datasets import download_file, download_sample_data
 from .utils.config import load_master_config
 from .utils._misc import _git_version
 from .utils.plugin import IPlugin, get_plugin, discover_plugins
+from .utils.testing import _enable_profiler
 
 
 #------------------------------------------------------------------------------
@@ -64,6 +65,15 @@ DEBUG = False
 if '--debug' in sys.argv:  # pragma: no cover
     DEBUG = True
     sys.argv.remove('--debug')
+
+
+# Add `profile` in the builtins.
+if '--lprof' in sys.argv or '--prof' in sys.argv:  # pragma: no cover
+    _enable_profiler('--lprof' in sys.argv)
+    if '--prof' in sys.argv:
+        sys.argv.remove('--prof')
+    if '--lprof' in sys.argv:
+        sys.argv.remove('--lprof')
 
 
 def test():  # pragma: no cover

--- a/phy/utils/cli.py
+++ b/phy/utils/cli.py
@@ -62,8 +62,10 @@ def _run_cmd(cmd, ctx, glob, loc):  # pragma: no cover
         _enable_pdb()
     if ctx.obj['ipython']:
         from IPython import start_ipython
-        args_ipy = ['-i', '-c="{}"'.format(cmd), '--gui=qt']
-        return start_ipython(args_ipy, user_ns={})
+        args_ipy = ['-i', '--gui=qt']
+        ns = glob.copy()
+        ns.update(loc)
+        return start_ipython(args_ipy, user_ns=ns)
     # Profiling. The builtin `profile` is added in __init__.
     prof = __builtins__.get('profile', None)
     if prof:

--- a/phy/utils/cli.py
+++ b/phy/utils/cli.py
@@ -15,10 +15,12 @@ import sys
 from traceback import format_exception
 
 import click
+from six import exec_
 
 from phy import (add_default_handler, DEBUG, _Formatter, _logger_fmt,
                  __version_git__, discover_plugins)
 from phy.utils import _fullname
+from phy.utils.testing import _enable_pdb, _enable_profiler, _profile
 
 logger = logging.getLogger(__name__)
 
@@ -54,17 +56,39 @@ def _add_log_file(filename):
     logging.getLogger().addHandler(handler)
 
 
+def _run_cmd(cmd, ctx, glob, loc):  # pragma: no cover
+    """Run a command with optionally a debugger, IPython, or profiling."""
+    if ctx.obj['pdb']:
+        _enable_pdb()
+    if ctx.obj['ipython']:
+        from IPython import start_ipython
+        args_ipy = ['-i', '-c="{}"'.format(cmd), '--gui=qt']
+        return start_ipython(args_ipy, user_ns={})
+    # Profiling. The builtin `profile` is added in __init__.
+    prof = __builtins__.get('profile', None)
+    if prof:
+        prof = __builtins__['profile']
+        return _profile(prof, cmd, glob, loc)
+    return exec_(cmd, glob, loc)
+
+
 #------------------------------------------------------------------------------
 # CLI tool
 #------------------------------------------------------------------------------
 
 @click.group()
+@click.option('--pdb', default=False, is_flag=True)
+@click.option('--ipython', default=False, is_flag=True)
 @click.version_option(version=__version_git__)
 @click.help_option('-h', '--help')
 @click.pass_context
-def phy(ctx):
+def phy(ctx, pdb=None, ipython=None, prof=None, lprof=None):
     """By default, the `phy` command does nothing. Add subcommands with plugins
     using `attach_to_cli()` and the `click` library."""
+    ctx.obj = {}
+
+    ctx.obj['pdb'] = pdb
+    ctx.obj['ipython'] = ipython
 
     # Create a `phy.log` log file with DEBUG level in the current directory.
     _add_log_file(op.join(os.getcwd(), 'phy.log'))

--- a/phy/utils/testing.py
+++ b/phy/utils/testing.py
@@ -171,6 +171,14 @@ def _profile(prof, statement, glob, loc):
         f.write(stats)
 
 
+def _enable_pdb():  # pragma: no cover
+    from IPython.core import ultratb
+    sys.excepthook = ultratb.FormattedTB(mode='Verbose',
+                                         color_scheme='Linux',
+                                         call_pdb=1,
+                                         )
+
+
 #------------------------------------------------------------------------------
 # Testing VisPy canvas
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Particularly useful during development and debugging

* `--pdb`: enable the IPython debugger
* `--ipython`: enable interactive IPython with the GUI
* `--prof`: profiler (saved in `.profile/stats.txt`)
* `--lprof`: line profiler (saved in `.profile/stats.txt`), need to specify profiled function with `@profile` decorator in the code