### PR TITLE
Call getargspec on func attribute for partial functions

### DIFF
--- a/phy/gui/actions.py
+++ b/phy/gui/actions.py
@@ -66,7 +66,10 @@ def _wrap_callback_args(f, docstring=None):  # pragma: no cover
     def wrapped(checked, *args):
         if args:
             return f(*args)
-        argspec = inspect.getargspec(f)
+        if isinstance(f, partial):
+            argspec = inspect.getargspec(f.func)
+        else:
+            argspec = inspect.getargspec(f)
         f_args = argspec.args
         if 'self' in f_args:
             f_args.remove('self')


### PR DESCRIPTION
Seems to fix #695 

Since f66848e, I have an error when I try to move a cluster. Calling getargspec on f.func for partial functions seems to solve the problem