### PR TITLE
Faster memcache that requires hashable arguments

### DIFF
--- a/phy/io/context.py
+++ b/phy/io/context.py
@@ -93,22 +93,19 @@ class Context(object):
                 dump(cache, fd)
 
     def memcache(self, f):
-        from joblib import hash
         name = _fullname(f)
         cache = self.load_memcache(name)
 
         @wraps(f)
-        def memcached(*args, **kwargs):
+        def memcached(*args):
             """Cache the function in memory."""
-            h = hash((args, kwargs))
-            if h in cache:
-                # logger.debug("Get %s(%s) from memcache.", name, str(args))
-                return cache[h]
-            else:
-                # logger.debug("Compute %s(%s).", name, str(args))
-                out = f(*args, **kwargs)
+            # The arguments need to be hashable. Much faster than using hash().
+            h = args
+            out = cache.get(h, None)
+            if out is None:
+                out = f(*args)
                 cache[h] = out
-                return out
+            return out
         return memcached
 
     def _get_path(self, name, location):

--- a/phy/io/tests/test_context.py
+++ b/phy/io/tests/test_context.py
@@ -99,7 +99,7 @@ def test_context_memcache(tempdir, context):
         return x ** 2
 
     # Compute the function a first time.
-    x = np.arange(10)
+    x = 10
     ae(f(x), x ** 2)
     assert len(_res) == 1
 


### PR DESCRIPTION
memcache is now faster, but it requires function arguments to be hashable (**no ndarrays**). Typically, this is used for `cluster_id => value` functions so this is okay.

There should be performance improvements when a memcached function is called many times with different arguments (example of the similarity function). Previously, the bottleneck was the computation of the hash of the function's arguments (using joblib's `hash()` function, which is overkill unless using ndarrays)