### PR TITLE
Update requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - matplotlib
   - scipy
   - h5py
-  - pyqt
+  - pyqt=4
   - pip:
     - vispy
     - requests

--- a/installer/environment.yml
+++ b/installer/environment.yml
@@ -1,16 +1,14 @@
 name: phy
-channels:
-  - kwikteam
 dependencies:
   - python
   - numpy
   - matplotlib
   - scipy
   - h5py
-  - pyqt
-  - klustakwik2
+  - pyqt=4
   - pip:
     - klusta
+    - klustakwik2
     - vispy
     - requests
     - traitlets

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,7 @@
-# Need development version of pytest for py35 compat
-# https://github.com/pytest-dev/pytest/issues/744
-git+https://github.com/pytest-dev/pytest.git
-
-# Need development version of pytest-qt for qtbot.wait() method
-git+https://github.com/pytest-dev/pytest-qt.git
-
+pytest
+pytest-qt
 flake8
-coverage==3.7.1
+coverage
 coveralls
 responses
 pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 norecursedirs = experimental _*
 
 [flake8]


### PR DESCRIPTION
conda now defaults PyQt to PyQt5 which is not yet compatible with phy. 

@nippoo I'll update soon the code from PyQt4 to PyQt5. Any argument against dropping PyQt4 support? I think it would be a pain to support both PyQt4 and PyQt5.