### PR TITLE
Factor out and fix plotting of FeatureView labels

### DIFF
--- a/phy/cluster/manual/views.py
+++ b/phy/cluster/manual/views.py
@@ -1099,21 +1099,17 @@ class FeatureView(ManualClusteringView):
 
     def _plot_labels(self, x_dim, y_dim):
         """Plot feature labels along left and bottom edge of subplots"""
-        dimlabels = []
-        for k in range(0, self.n_cols):
-            dimlabels.append(str(y_dim[(k, k)]))
-
         j = 0
         for i in range(0, self.n_cols):
             self[i, j].text(pos=[-1., 0.],
-                            text=dimlabels[i],
+                            text=str(y_dim[(i, i)]),
                             anchor=[-1.03, 0.],
                             data_bounds=None,
                             )
         i = self.n_cols - 1
         for j in range(0, self.n_cols):
             self[i, j].text(pos=[0., -1.],
-                            text=dimlabels[j],
+                            text=str(y_dim[(j, j)]),
                             anchor=[0., -1.04],
                             data_bounds=None,
                             )

--- a/phy/cluster/manual/views.py
+++ b/phy/cluster/manual/views.py
@@ -1102,20 +1102,21 @@ class FeatureView(ManualClusteringView):
 
         # iterate simultaneously over kth row in left column and
         # kth column in bottom row:
+        br = self.n_cols - 1 # bottom row
         for k in range(0, self.n_cols):
             label = str(y_dim[k, k])
-            # left edge of subplots:
+            # left edge of left column of subplots:
             self[k, 0].text(pos=[-1., 0.],
                             text=label,
                             anchor=[-1.03, 0.],
                             data_bounds=None,
                             )
-            # bottom edge of subplots:
-            self[self.n_cols-1, k].text(pos=[0., -1.],
-                                        text=label,
-                                        anchor=[0., -1.04],
-                                        data_bounds=None,
-                                        )
+            # bottom edge of bottom row of subplots:
+            self[br, k].text(pos=[0., -1.],
+                             text=label,
+                             anchor=[0., -1.04],
+                             data_bounds=None,
+                             )
 
     def _get_channel_dims(self, cluster_ids):
         """Select the channels to show by default."""

--- a/phy/cluster/manual/views.py
+++ b/phy/cluster/manual/views.py
@@ -1096,21 +1096,25 @@ class FeatureView(ManualClusteringView):
                            data_bounds=None,
                            uniform=True,
                            )
-        if i == 0:
-            # HACK: call this when i=0 (first line) but plot the text
-            # in the last subplot line. This is because we skip i > j
-            # in the subplot loop.
-            i0 = (self.n_cols - 1)
-            dim = x_dim[i0, j] if j < (self.n_cols - 1) else x_dim[i0, 0]
-            self[i0, j].text(pos=[0., -1.],
-                             text=str(dim),
-                             anchor=[0., -1.04],
-                             data_bounds=None,
-                             )
-        if j == 0:
+
+    def _plot_labels(self, x_dim, y_dim):
+        """Plot feature labels along left and bottom edge of subplots"""
+        dimlabels = []
+        for k in range(0, self.n_cols):
+            dimlabels.append(str(y_dim[(k, k)]))
+
+        j = 0
+        for i in range(0, self.n_cols):
             self[i, j].text(pos=[-1., 0.],
-                            text=str(y_dim[i, j]),
+                            text=dimlabels[i],
                             anchor=[-1.03, 0.],
+                            data_bounds=None,
+                            )
+        i = self.n_cols - 1
+        for j in range(0, self.n_cols):
+            self[i, j].text(pos=[0., -1.],
+                            text=dimlabels[j],
+                            anchor=[0., -1.04],
                             data_bounds=None,
                             )
 
@@ -1184,6 +1188,7 @@ class FeatureView(ManualClusteringView):
 
         # Plot all features.
         with self.building():
+            self._plot_labels(x_dim, y_dim)
             for i in range(self.n_cols):
                 for j in range(self.n_cols):
                     # Skip lower-diagonal subplots.

--- a/phy/cluster/manual/views.py
+++ b/phy/cluster/manual/views.py
@@ -1099,20 +1099,22 @@ class FeatureView(ManualClusteringView):
 
     def _plot_labels(self, x_dim, y_dim):
         """Plot feature labels along left and bottom edge of subplots"""
-        j = 0
-        for i in range(0, self.n_cols):
-            self[i, j].text(pos=[-1., 0.],
-                            text=str(y_dim[i, i]),
+
+        # iterate simultaneously over kth row in left column and kth column in bottom row:
+        for k in range(0, self.n_cols):
+            label = str(y_dim[k, k])
+            # left edge of subplots:
+            self[k, 0].text(pos=[-1., 0.],
+                            text=label,
                             anchor=[-1.03, 0.],
                             data_bounds=None,
                             )
-        i = self.n_cols - 1
-        for j in range(0, self.n_cols):
-            self[i, j].text(pos=[0., -1.],
-                            text=str(y_dim[j, j]),
-                            anchor=[0., -1.04],
-                            data_bounds=None,
-                            )
+            # bottom edge of subplots:
+            self[self.n_cols-1, k].text(pos=[0., -1.],
+                                   text=label,
+                                   anchor=[0., -1.04],
+                                   data_bounds=None,
+                                   )
 
     def _get_channel_dims(self, cluster_ids):
         """Select the channels to show by default."""

--- a/phy/cluster/manual/views.py
+++ b/phy/cluster/manual/views.py
@@ -1100,7 +1100,8 @@ class FeatureView(ManualClusteringView):
     def _plot_labels(self, x_dim, y_dim):
         """Plot feature labels along left and bottom edge of subplots"""
 
-        # iterate simultaneously over kth row in left column and kth column in bottom row:
+        # iterate simultaneously over kth row in left column and
+        # kth column in bottom row:
         for k in range(0, self.n_cols):
             label = str(y_dim[k, k])
             # left edge of subplots:
@@ -1111,10 +1112,10 @@ class FeatureView(ManualClusteringView):
                             )
             # bottom edge of subplots:
             self[self.n_cols-1, k].text(pos=[0., -1.],
-                                   text=label,
-                                   anchor=[0., -1.04],
-                                   data_bounds=None,
-                                   )
+                                        text=label,
+                                        anchor=[0., -1.04],
+                                        data_bounds=None,
+                                        )
 
     def _get_channel_dims(self, cluster_ids):
         """Select the channels to show by default."""

--- a/phy/cluster/manual/views.py
+++ b/phy/cluster/manual/views.py
@@ -1102,7 +1102,7 @@ class FeatureView(ManualClusteringView):
 
         # iterate simultaneously over kth row in left column and
         # kth column in bottom row:
-        br = self.n_cols - 1 # bottom row
+        br = self.n_cols - 1  # bottom row
         for k in range(0, self.n_cols):
             label = str(y_dim[k, k])
             # left edge of left column of subplots:

--- a/phy/cluster/manual/views.py
+++ b/phy/cluster/manual/views.py
@@ -1102,14 +1102,14 @@ class FeatureView(ManualClusteringView):
         j = 0
         for i in range(0, self.n_cols):
             self[i, j].text(pos=[-1., 0.],
-                            text=str(y_dim[(i, i)]),
+                            text=str(y_dim[i, i]),
                             anchor=[-1.03, 0.],
                             data_bounds=None,
                             )
         i = self.n_cols - 1
         for j in range(0, self.n_cols):
             self[i, j].text(pos=[0., -1.],
-                            text=str(y_dim[(j, j)]),
+                            text=str(y_dim[j, j]),
                             anchor=[0., -1.04],
                             data_bounds=None,
                             )


### PR DESCRIPTION
I've noticed two issues with the FeatureView labels, which make things very confusing for a new user:

1. Most of the labels are missing along the left edge of the subplots.
2. The label value in the bottom right corner is wrong.

This separates setting the FeatureView labels from the (iterated) plotting commands, gets rid of a hack, and fixes the two issues above. This is a rather quick and naive stab at the code, but it seems to work.

Here is what it looks like before the fix:

![before](https://cloud.githubusercontent.com/assets/799467/19864383/4b887ece-9f98-11e6-9518-32f64672a69b.png)

And here is what it looks like after:

![after](https://cloud.githubusercontent.com/assets/799467/19864388/502149fc-9f98-11e6-8f0b-d30f8f725134.png)

