### PR TITLE
Fix bug in correlograms actions

### DIFF
--- a/phy/cluster/views/correlogram.py
+++ b/phy/cluster/views/correlogram.py
@@ -150,8 +150,8 @@ class CorrelogramView(ManualClusteringView):
         super(CorrelogramView, self).attach(gui)
         self.actions.add(self.toggle_normalization, shortcut='n', checkable=True)
         self.actions.separator()
-        self.actions.add(self.set_bin, alias='cb')
-        self.actions.add(self.set_window, alias='cw')
+        self.actions.add(self.set_bin, alias='cb', prompt=True)
+        self.actions.add(self.set_window, alias='cw', prompt=True)
 
     @property
     def state(self):


### PR DESCRIPTION
this fixes https://github.com/kwikteam/phy/issues/813 in the gloo branch

Without the `prompt=True` the window to change bin size and window size doesn't show

Cheers
Alessio